### PR TITLE
[BUGFIX] fix typo in composer.json #1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "maximebf/debugbar": "^1.15"
   },
   "replace": {
-    "typo_debugbar": "self.version"
+    "typo3_debugbar": "self.version"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This fixes the error:
TYPO3 Fatal Error: Extension key "typo3_debugbar" is NOT loaded